### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 mockery
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/9faef47671234913b5b2a9ef817f7e97)](https://app.codacy.com/gh/namely/mockery/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/9faef47671234913b5b2a9ef817f7e97)](https://app.codacy.com/gh/namely/mockery/dashboard)
 =======
 
 This repo is a fork of https://github.com/vektra/mockery fixing compatibility

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-mockery
+# mockery
  
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/9faef47671234913b5b2a9ef817f7e97)](https://app.codacy.com/gh/namely/mockery/dashboard)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/9faef47671234913b5b2a9ef817f7e97)](https://app.codacy.com/gh/namely/mockery/dashboard)
-=======
 
 This repo is a fork of https://github.com/vektra/mockery fixing compatibility
 with go 1.13 in addition to adding strongly typed expectations.


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.